### PR TITLE
Fixed the script removing comments // located within strings

### DIFF
--- a/scribe.py
+++ b/scribe.py
@@ -316,7 +316,7 @@ def string2json(string):
     t = re.sub(r"//.*", "", t)
     #Restore the strings between quotes
     for i in range (0, len(quotes)):
-        quote = re.sub(r"\"", re.escape("\\") + "\"", quotes[i].strip())
+        quote = quotes[i]
         t = re.sub(r"FLAGQUOTE",  quote, t, 1)
     #Remove the comments between /* and */
     t = re.sub(r"/\*.*?\t*?\*/", "", t, flags=re.DOTALL)

--- a/scribe.py
+++ b/scribe.py
@@ -309,8 +309,15 @@ def jsonToMap(content, outputDirectory, mapName, clean):
 
 
 def string2json(string):
+    #Find and replace anything between quotes to protect them from the next check
+    quotes = re.findall(r"['\"].*?['\"]", string)
+    t = re.sub(r"['\"].*?['\"]", "FLAGQUOTE", string)
     #Remove the comments preceded by //
-    t = re.sub(r"//.*", "", string)
+    t = re.sub(r"//.*", "", t)
+    #Restore the strings between quotes
+    for i in range (0, len(quotes)):
+        quote = re.sub(r"\"", re.escape("\\") + "\"", quotes[i].strip())
+        t = re.sub(r"FLAGQUOTE",  quote, t, 1)
     #Remove the comments between /* and */
     t = re.sub(r"/\*.*?\t*?\*/", "", t, flags=re.DOTALL)
     #Find and replace the comments preceded by ##


### PR DESCRIPTION
This adds some steps to how a Scribe file is converted to a Mapfile. First, it replaces every string between 'quotes' or "double quotes" by a temporary string. Then, it removes the //comments within the Scribe file, exactly as before. Afterwards, it restores the strings that were replaced earlier. 

This is to fix [an issue in ScribeUI](https://github.com/mapgears/scribeui/issues/113) where some links such as http://www... are interpreted as comments and cut in half.