### PR TITLE
Improved the double-slash comment removal

### DIFF
--- a/scribe.py
+++ b/scribe.py
@@ -309,15 +309,8 @@ def jsonToMap(content, outputDirectory, mapName, clean):
 
 
 def string2json(string):
-    #Find and replace anything between quotes to protect them from the next check
-    quotes = re.findall(r"['\"].*?['\"]", string)
-    t = re.sub(r"['\"].*?['\"]", "FLAGQUOTE", string)
     #Remove the comments preceded by //
-    t = re.sub(r"//.*", "", t)
-    #Restore the strings between quotes
-    for i in range (0, len(quotes)):
-        quote = quotes[i]
-        t = re.sub(r"FLAGQUOTE",  quote, t, 1)
+    t = re.sub(ur'("(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|(?:[^/\n"\']|/[^/*\n"\'])+|\n)|(/\*  (?:[^*]|\*[^/])*\*/)|(?://(.*)$)$', lambda m: m.group(1), string, flags=re.MULTILINE)
     #Remove the comments between /* and */
     t = re.sub(r"/\*.*?\t*?\*/", "", t, flags=re.DOTALL)
     #Find and replace the comments preceded by ##


### PR DESCRIPTION
It worked fine with this map:
```
//Bienvenue sur ma carte!
//Par Samuel "Déjeuner d'aujourd'hui" Lapointe
MAP {
    CONFIG: 'ON_MISSING_DATA' 'IGNORE'
    ##CONFIG: "MS_ERRORFILE" "../debugFile.log"
    CONFIG: 'PROJ_LIB' '../'
    FONTSET: '../fonts.lst'
    IMAGETYPE: png
    MAXSIZE: 4000
    SIZE: 800 800
    UNITS: meters
    EXTENT: -20405648.939901 -17712669.979681 20314497.045109 19408951.476421
    IMAGECOLOR: '#C6E2F2'
    SHAPEPATH: '../pdata/natural_earth/'
    WEB {
        METADATA {{
            "ows_enable_request"   "*"
            "wms_srs"   "EPSG:900913 EPSG:4326 EPSG:3857"
            "labelcache_map_edge_buffer"   "10"
            "wms_title"   "grid"
            "wms_onlineresource"    "http://mapserver.com:8081/cgi-bin/mapserv?map=/opt/scribeui/workspaces/blabla.map" //Un lien!
        }}
        IMAGEPATH: '/tmp/ms_tmp/'
        IMAGEURL: '/ms_tmp/'
    }
    DEBUG: 5
    PROJECTION {{
        "init=epsg:900913"
    }}
    INCLUDE: '../symbols.map'
}//C'est la fin!
```