### PR TITLE
Added an option to debug the map using shp2img

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,8 @@ python scribe.py -n outputmapname
     Other options
     -------------
         -c/--clean: If this option is specified, the layers from each scale level are included in the output mapfile with 'INCLUDE' tags. If not specified, the content of each scale level is outputted directly in the resulting mapfile.  
+        -d/--debug: The parameter is a number from 0 to 5. If this option is added, the output map will be verified with shp2img with
+        the specified debug level. A debug.png map will also be rendered and placed in the output directory.
     
 Input
 -----

--- a/scribe.py
+++ b/scribe.py
@@ -538,7 +538,9 @@ def list2dict(ls):
 
 def debugMapfile(outputDirectory, mapName, level):
     sub = subprocess.Popen('shp2img -m ' + outputDirectory + mapName + '.map -all_debug ' + str(level) + ' -o ' + outputDirectory + ' debug.png', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) 
-    logs = sub.stderr.read().strip() + sub.stdout.read().strip()
+    logs = 'Mapserver logs (debug level ' + str(level) + ')\n'
+    logs += '------------------------------\n'
+    logs += sub.stderr.read().strip() + sub.stdout.read().strip()
     print >> sys.stdout, logs
     return
 
@@ -651,7 +653,7 @@ def main():
                 
             try:
                 jsonToMap(jsonContent, outputDirectory, mapName, clean)
-                if(debugLevel >= 0 and debugLevel <= 5): #debug using shp2img
+                if debugLevel >= 0 and debugLevel <= 5: #debug using shp2img
                     debugMapfile(outputDirectory, mapName, debugLevel)
             except ValueError:
                 exc_traceback = sys.exc_info()[2]

--- a/scribe.py
+++ b/scribe.py
@@ -2,6 +2,7 @@
 # -*- coding: iso-8859-1 -*-
 
 import json
+import subprocess
 import re
 import getopt, sys, traceback
 import os.path
@@ -535,6 +536,11 @@ def list2dict(ls):
             dc[key] = item[key]
     return dc
 
+def debugMapfile(outputDirectory, mapName, level):
+    sub = subprocess.Popen('shp2img -m ' + outputDirectory + mapName + '.map -all_debug ' + str(level) + ' -o ' + outputDirectory + ' debug.png', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) 
+    logs = sub.stderr.read().strip() + sub.stdout.read().strip()
+    print >> sys.stdout, logs
+    return
 
 def main():
     global INDENTATION
@@ -547,9 +553,10 @@ def main():
     clean = False
     error = ""
     outputJSONFile = None
+    debugLevel = -1
 
     try:                                
-        opts, args = getopt.getopt(sys.argv[1:], "i:o:n:cf:t:j:", ["input", "output", "name", "clean", "file","tabulation", "json"])
+        opts, args = getopt.getopt(sys.argv[1:], "i:o:n:cf:t:j:d:", ["input", "output", "name", "clean", "file","tabulation", "json", "debug"])
     except getopt.GetoptError as err:
         print >> sys.stderr, str(err)                      
         sys.exit(2) 
@@ -569,6 +576,8 @@ def main():
             INDENTATION = int(arg)
         elif opt in ("-j", "--json"):
             outputJSONFile = arg
+        elif opt in ("-d", "--debug"):
+            debugLevel = int(arg)
             
     if os.path.isfile(inputDirectory + "scales"):
         inputScalesFile = codecs.open(inputDirectory + "scales", encoding='utf-8')
@@ -642,6 +651,8 @@ def main():
                 
             try:
                 jsonToMap(jsonContent, outputDirectory, mapName, clean)
+                if(debugLevel >= 0 and debugLevel <= 5): #debug using shp2img
+                    debugMapfile(outputDirectory, mapName, debugLevel)
             except ValueError:
                 exc_traceback = sys.exc_info()[2]
                 print >> sys.stderr, "Uncatched syntax error :"
@@ -649,7 +660,7 @@ def main():
     else:
         print >> sys.stderr, error
         sys.exit(2)
-
+        
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is the first step in my project to debug the scribe files in ScribeUI. Right now, it only displays the raw output of shp2img. The next step will be getting a clearer error output, accurate to the scribe files, using this debug output.